### PR TITLE
added jquery source map to chrome manifest

### DIFF
--- a/firefox/content/disconnect.safariextension/opera/chrome/manifest.json
+++ b/firefox/content/disconnect.safariextension/opera/chrome/manifest.json
@@ -47,5 +47,6 @@
     ],
     "run_at": "document_start",
     "all_frames": true
-  }]
+  }],
+  "web_accessible_resources": ["scripts/vendor/jquery/jquery-2.0.3.min.map"]
 }


### PR DESCRIPTION
Chrome dev console is spitting out this error again:

```
Denying load of chrome-extension://ekmfaeljlmjncfnpfehgdhglekkblbga/scripts/vendor/jquery/jquery-2.0.3.min.map. Resources must be listed in the web_accessible_resources manifest key in order to be loaded by pages outside the extension. 
```

Adding the .map file to the manifest fixes the problem.
