### PR TITLE
Update port.js to latest version with fixed localstorage error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,7 +76,7 @@ These libraries are bundled with the project and needn’t be updated manually:
 * [jQuery](https://github.com/jquery/jquery)
 * [SJCL](https://github.com/bitwiseshiftleft/sjcl)
 * [D3.js](https://github.com/mbostock/d3)
-* [port.js](https://github.com/disconnectme/port)
+* [port.js](https://github.com/oldestlivingboy/port)
 * [sitename.js](https://github.com/disconnectme/sitename)
 * [favicon.js](https://github.com/disconnectme/favicon)
 

--- a/firefox/content/disconnect.safariextension/opera/chrome/scripts/vendor/port/port.js
+++ b/firefox/content/disconnect.safariextension/opera/chrome/scripts/vendor/port/port.js
@@ -27,7 +27,15 @@ SAFARI = (typeof safari !== "undefined");
 LEGACY_SAFARI = SAFARI && (navigator.appVersion.match(/\sSafari\/(\d+)\./) || [null,0])[1] < 534;
 
 // "localStorage" gets cleared too often in Safari to rely on.
-options = SAFARI ? safari.extension.settings : localStorage;
+if (SAFARI) {
+  options = safari.extension.settings;
+} else {
+  try {
+    options = localStorage;
+  } catch(e) {
+    options = {}; // fallback if localStorage is unavailable
+  }
+}
 
 if (SAFARI) {
 


### PR DESCRIPTION
Fixes #315 by upgrading `port.js` with this patch https://github.com/oldestlivingboy/port/pull/1. See discussion here https://github.com/disconnectme/port/issues/1