### PR TITLE
add content-security-policy

### DIFF
--- a/firefox/content/disconnect.safariextension/opera/chrome/manifest.json
+++ b/firefox/content/disconnect.safariextension/opera/chrome/manifest.json
@@ -4,6 +4,7 @@
   "version": "5.19.3",
   "description": "Make the web faster, more private, and more secure.",
   "icons": {"48": "images/48.png", "128": "images/128.png"},
+  "content_security_policy": "default-src 'none'; script-src 'self'; object-src 'self'; connect-src mxr.mozilla.org;",
   "permissions": [
     "cookies",
     "tabs",

--- a/firefox/content/disconnect.safariextension/opera/manifest.json
+++ b/firefox/content/disconnect.safariextension/opera/manifest.json
@@ -4,6 +4,7 @@
   "version": "5.19.2",
   "description": "Make the web faster, more private, and more secure.",
   "icons": {"48": "chrome/images/48.png", "128": "chrome/images/128.png"},
+  "content_security_policy": "default-src 'none'; script-src 'self'; object-src 'self'; connect-src mxr.mozilla.org;",
   "permissions": [
     "cookies",
     "tabs",


### PR DESCRIPTION
This just adds content-security-policy to Chrome/Firefox/Opera manifests which should decrease risk score on https://crxcavator.io/report/jeoacafpbcihiomhlakheieifhpjdfeo?platform=Chrome&new_scan=true

From quick search, I only found mxr.mozilla.org as XMLHTTPRequest which would need connect-src. Others are generic code from jquery.
Note that crxcavator also identified multiple javascript libraries which would need an update. (low to medium severity)
